### PR TITLE
Hot Fix: Polygon mainnet network selection unavailable

### DIFF
--- a/src/components/organization/walletCommonComponents/SharedAgent.tsx
+++ b/src/components/organization/walletCommonComponents/SharedAgent.tsx
@@ -212,7 +212,7 @@ const SharedAgentForm = ({
 
 		let filteredNetworks = Object.keys(networks);
 		if (selectedMethod === DidMethod.POLYGON) {
-			filteredNetworks = filteredNetworks.filter(network => network === Network.TESTNET);
+			filteredNetworks = filteredNetworks.filter(network => network === Network.TESTNET || Network.MAINNET);
 		}
 
 		return filteredNetworks.map((network) => (


### PR DESCRIPTION
- Fixing the polygon mainnet network unavailable issue in the studio while creating the organization